### PR TITLE
Show that the issue has been assigned

### DIFF
--- a/ckanext/issues/templates/issues/show.html
+++ b/ckanext/issues/templates/issues/show.html
@@ -252,6 +252,8 @@ endfor %}">
     {% if issue.assignee %}
       {{ h.gravatar((issue.assignee.email_hash), size=22) }}
       {{ issue.assignee.name }}
+    {% elif issue.assignee_id %}
+      {{ _('This issue has been assigned to an administrator for the publisher') }}
     {% else %}
       {{ _('No one') }}
     {% endif %}


### PR DESCRIPTION
If the issue has been assigned, but the user does not have enough rights to do
user_show on the assignee it should still show that it has been assigned to
someone.

Fixes #51
